### PR TITLE
Make TestProbe a RecipientRef

### DIFF
--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/internal/TestProbeImpl.scala
@@ -16,6 +16,7 @@ import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
 
+import akka.actor.ActorRefProvider
 import akka.actor.testkit.typed.FishingOutcome
 import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.javadsl.{ TestProbe => JavaTestProbe }
@@ -26,6 +27,7 @@ import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
 import akka.actor.typed.Signal
 import akka.actor.typed.Terminated
+import akka.actor.typed.internal.InternalRecipientRef
 import akka.actor.typed.scaladsl.Behaviors
 import akka.annotation.InternalApi
 import akka.japi.function.Creator
@@ -63,7 +65,8 @@ private[akka] object TestProbeImpl {
 @InternalApi
 private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
     extends JavaTestProbe[M]
-    with ScalaTestProbe[M] {
+    with ScalaTestProbe[M]
+    with InternalRecipientRef[M] {
 
   import TestProbeImpl._
 
@@ -389,6 +392,14 @@ private[akka] final class TestProbeImpl[M](name: String, system: ActorSystem[_])
   override def stop(): Unit = {
     testActor.asInstanceOf[ActorRef[AnyRef]] ! Stop
   }
+
+  def tell(m: M) = testActor.tell(m)
+
+  // impl InternalRecipientRef, ask isn't supported
+  def provider: ActorRefProvider = throw new UnsupportedOperationException("ask pattern not supported")
+
+  // impl InternalRecipientRef, only used by ask pattern
+  def isTerminated: Boolean = false
 
   override private[akka] def asJava: JavaTestProbe[M] = this
 }

--- a/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
+++ b/akka-actor-testkit-typed/src/main/scala/akka/actor/testkit/typed/scaladsl/TestProbe.scala
@@ -13,6 +13,8 @@ import akka.actor.testkit.typed.TestKitSettings
 import akka.actor.testkit.typed.internal.TestProbeImpl
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
+import akka.actor.typed.RecipientRef
+import akka.actor.typed.internal.InternalRecipientRef
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalApi
 
@@ -56,7 +58,7 @@ object TestProbe {
  *
  * Not for user extension
  */
-@DoNotInherit trait TestProbe[M] {
+@DoNotInherit trait TestProbe[M] extends RecipientRef[M] { this: InternalRecipientRef[M] =>
 
   implicit protected def settings: TestKitSettings
 


### PR DESCRIPTION
This is some noodling on an idea.

`TestProbe` seems to satisfy all the external interface contracts of a `RecipientRef` (viz. you can send it messages), so this seems like the sort of thing that would be useful in perhaps some bizarre set of circumstances; if nothing else, it would eliminate explicitly calling `ref`.