### PR TITLE
Don't use Scala 2.x options in Scala 3.y (where y > 0)

### DIFF
--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -48,7 +48,7 @@ object JdkOptions extends AutoPlugin {
       targetSystemJdk,
       jdk8home,
       fullJavaHomes,
-      Seq(if (scalaVersion.startsWith("3.0")) "-Xtarget:8" else "-target:jvm-1.8"),
+      Seq(if (scalaVersion.startsWith("3.")) "-Xtarget:8" else "-target:jvm-1.8"),
       // '-release 8' is not enough, for some reason we need the 8 rt.jar
       // explicitly. To test whether this has the desired effect, compile
       // akka-remote and check the invocation of 'ByteBuffer.clear()' in


### PR DESCRIPTION
With this change, I can now successfully compile: `++3.1.2 compile`.

Before this change:

```
[error] bad option '-target:jvm-1.8' was ignored
[error] one error found
[error] (akka-actor / Compile / compileIncremental) Compilation failed
```

I will admit that I'm a bit mystified by how 3.1.2 works in CI...