### PR TITLE
Introduce mapAsyncPartitioned

### DIFF
--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
@@ -24,15 +24,13 @@ If `parallelism` is 1, this stage is equivalent to @ref[`mapAsyncUnordered`](map
 
 ## Examples
 
-Imagine you are consuming messages from a broker.  These messages represent business events produced by some other service(s) and each concerns a particular entity.  You may process messages for different entities simultaneously, but can only process one message for a given entity at a time:
+Imagine you are consuming messages from a broker.  This broker's semantics are such that acknowledging one message implies an acknowledgement of all messages delivered before that message; this in turn means that in order to ensure at-least-once processing of messages from the broker, they must be acknowledged in the order they were received.  These messages represent business events produced by some other service(s) and each concerns a particular entity.  You may process messages for different entities simultaneously, but can only process one message for a given entity at a time:
 
 Scala
 :   @@snip [MapAsyncs.scala](/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapAsyncs.scala) { #mapAsyncPartitioned }
 
 Java
 :   @@snip [MapAsyncs.java](/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapAsyncs.java) { #mapAsyncPartitioned }
-
-Because the message broker uses a "cumulative ack" (similar to a Kafka offset commit) where acknowledging one message implies an acknowledgement of all messages delivered before that message, the emission order must correspond to the order in which the messages were consumed.
 
 We can see from the (annotated) logs the order of consumption, processing, and emission:
 

--- a/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
+++ b/akka-docs/src/main/paradox/stream/operators/Source-or-Flow/mapAsyncPartitioned.md
@@ -1,0 +1,128 @@
+# mapAsyncPartitioned
+
+Pass incoming elements to a function that assigns a partitioning key, then to a function that returns a @scala[`Future`] @java[`CompletionStage`] result, bounding the number of incomplete @scala[futures] @java[`CompletionStage` s] per partitioning key.
+
+@ref[Asynchronous operators](../index.md#asynchronous-operators)
+
+## Signature
+
+@apidoc[Source.mapAsyncPartitioned](Source) { scala="#mapAsyncPartitioned[T,P](parallelism:Int,perPartition:Int)(partitioner:Out=%3EP)(f:(Out,P)=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncPartitioned(int,int,akka.japi.function.Function,java.util.function.BiFunction" }
+@apidoc[Flow.mapAsyncPartitioned](Flow) { scala="#mapAsyncPartitioned[T,P](parallelism:Int,perPartition:Int)(partitioner:Out=%3EP)(f:(Out,P)=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]" java="#mapAsyncPartitioned(int,int,akka.japi.function.Function,java.util.function.BiFunction" }
+
+## Description
+
+Pass incoming elements to a function that assigns a partitioning key, then to function that returns a @scala[`Future`] @java[`CompletionStage`] result.  When the @scala[future] @java[`CompletionStage`] completes successfully, the result is passed downstream.
+
+Up to `parallelism` futures can be processed concurrently; additionally no more than `perPartition` @scala[futures] @java[`CompletionStage` s] with the same partitioning key will be incomplete at any time.
+
+Regardless of completion order, results will be emitted in order of the incoming elements which gave rise to the @scala[future] @java[`CompletionStage`].
+
+If a @scala[`Future`] @java[`CompletionStage`] completes with `null`, that result is not emitted.
+If a @scala[`Future`] @java[`CompletionStage`] completes with failure, the stream's supervision strategy may fail the stream or drop the element.
+
+If `parallelism` is 1, this stage is equivalent to @ref[`mapAsyncUnordered`](mapAsyncUnordered.md).  If `perPartition` is greater-than or equal to `parallelism`, this stage is equivalent to @ref[`mapAsync`](mapAsync.md).
+
+## Examples
+
+Imagine you are consuming messages from a broker.  These messages represent business events produced by some other service(s) and each concerns a particular entity.  You may process messages for different entities simultaneously, but can only process one message for a given entity at a time:
+
+Scala
+:   @@snip [MapAsyncs.scala](/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapAsyncs.scala) { #mapAsyncPartitioned }
+
+Java
+:   @@snip [MapAsyncs.java](/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapAsyncs.java) { #mapAsyncPartitioned }
+
+Because the message broker uses a "cumulative ack" (similar to a Kafka offset commit) where acknowledging one message implies an acknowledgement of all messages delivered before that message, the emission order must correspond to the order in which the messages were consumed.
+
+We can see from the (annotated) logs the order of consumption, processing, and emission:
+
+```
+Received event EntityEvent(0,1) at offset 0 from message broker
+Assigned event EntityEvent(0,1) to partition 0
+Processing event EntityEvent(0,1) from partition 0
+Received event EntityEvent(0,2) at offset 1 from message broker
+Assigned event EntityEvent(0,2) to partition 0                   # see note 1
+Received event EntityEvent(0,3) at offset 2 from message broker
+Assigned event EntityEvent(0,3) to partition 0
+Received event EntityEvent(3,1) at offset 3 from message broker
+Assigned event EntityEvent(3,1) to partition 3
+Processing event EntityEvent(3,1) from partition 3              # see note 2
+Received event EntityEvent(3,2) at offset 4 from message broker
+Assigned event EntityEvent(3,2) to partition 3
+Received event EntityEvent(2,1) at offset 5 from message broker
+Assigned event EntityEvent(2,1) to partition 2
+Processing event EntityEvent(2,1) from partition 2
+Received event EntityEvent(6,1) at offset 6 from message broker
+Assigned event EntityEvent(6,1) to partition 6
+Completed processing 3-1                                        # see note 3
+Processing event EntityEvent(6,1) from partition 6
+Received event EntityEvent(1,1) at offset 7 from message broker
+Assigned event EntityEvent(1,1) to partition 1
+Processing event EntityEvent(1,1) from partition 1
+Received event EntityEvent(1,2) at offset 8 from message broker
+Assigned event EntityEvent(1,2) to partition 1
+Received event EntityEvent(5,1) at offset 9 from message broker
+Assigned event EntityEvent(5,1) to partition 5
+Processing event EntityEvent(5,1) from partition 5
+Completed processing 5-1
+Processing event EntityEvent(3,2) from partition 3
+Completed processing 2-1
+Completed processing 0-1
+Processing event EntityEvent(0,2) from partition 0                # see note 4
+`mapAsyncPartitioned` emitted 0-1                                 # see note 5
+Received event EntityEvent(3,3) at offset 10 from message broker
+Assigned event EntityEvent(3,3) to partition 3
+Completed processing 0-2
+Processing event EntityEvent(0,3) from partition 0
+`mapAsyncPartitioned` emitted 0-2                                 # see note 6
+Received event EntityEvent(0,4) at offset 11 from message broker
+Assigned event EntityEvent(0,4) to partition 0
+Completed processing 3-2
+Processing event EntityEvent(3,3) from partition 3
+Completed processing 3-3
+Completed processing 1-1
+Processing event EntityEvent(1,2) from partition 1
+Completed processing 1-2
+Completed processing 6-1
+Completed processing 0-3
+Processing event EntityEvent(0,4) from partition 0
+Completed processing 0-4
+`mapAsyncPartitioned` emitted 0-3
+`mapAsyncPartitioned` emitted 3-1                                # see note 7
+Received event EntityEvent(4,1) at offset 12 from message broker
+Assigned event EntityEvent(4,1) to partition 4
+Processing event EntityEvent(4,1) from partition 4
+`mapAsyncPartitioned` emitted 3-2
+Received event EntityEvent(8,1) at offset 13 from message broker
+Assigned event EntityEvent(8,1) to partition 8
+Processing event EntityEvent(8,1) from partition 8
+`mapAsyncPartitioned` emitted 2-1
+Completed processing 8-1
+Received event EntityEvent(9,1) at offset 14 from message broker
+Assigned event EntityEvent(9,1) to partition 9
+Processing event EntityEvent(9,1) from partition 9
+`mapAsyncPartitioned` emitted 6-1
+Received event EntityEvent(1,3) at offset 15 from message broker
+```
+
+Notes:
+
+1. The second (offset 1) message received is for the same entity as the earlier (offset 0) message.  Because that earlier message's processing has not yet completed, processing of this message (beyond assigning it to a partition corresponding to the entity, which always happens immediately in `mapAsyncPartitioned`) has not started.
+2. The fourth (offset 3) message received is for a different entity from the previous messages.  It therefore starts processing immediately, even though the messages at offsets 1 and 2 are waiting to start processing.
+3. That fourth message completes processing before any other message, but its result will not be emitted until all earlier results are emitted.
+4. Once the first message is completed, processing of the next message in its partition (in this case, from offset 1) can begin.
+5. The first result emitted arose from the first message received, which allows the 11th message (offset 10) to be consumed from the message broker, ensuring that no more than 10 messages are being processed asynchronously at any given time.
+6. The second result emitted arose from the second message received.
+7. Immediately after the result of processing the third message received is emitted, the result of processing the fourth message is emitted.
+
+## Reactive Streams semantics
+
+@@@div { .callout }
+
+**emits** when the @scala[`Future`] @java[`CompletionStage`] returned by the provided function completes successfully and all @scala[futures] @java[`CompletionStage` s] from elements preceding this one have completed and been emitted (if successful)
+
+**backpressures** when the number of elements for which no @scala[`Future`] @java[`CompletionStage`] has completed reaches the configured parallelism and the downstream backpressures
+
+**completes** when upstream completes and all @scala[`Future` s] @java[`CompletionStage` s] have completed and all results have been emitted
+
+@@@

--- a/akka-docs/src/main/paradox/stream/operators/index.md
+++ b/akka-docs/src/main/paradox/stream/operators/index.md
@@ -198,6 +198,7 @@ operation at the same time (usually handling the completion of a @scala[`Future`
 | |Operator|Description|
 |--|--|--|
 |Source/Flow|<a name="mapasync"></a>@ref[mapAsync](Source-or-Flow/mapAsync.md)|Pass incoming elements to a function that return a @scala[`Future`] @java[`CompletionStage`] result.|
+|Source/Flow|<a name="mapasyncpartitioned"></a>@ref[mapAsyncPartitioned](Source-or-Flow/mapAsyncPartitioned.md)|Pass incoming elements to a function that assigns a partitioning key, then to a function that returns a @scala[`Future`] @java[`CompletionStage`] result, bounding the number of incomplete @scala[futures] @java[`CompletionStage` s] per partitioning key.|
 |Source/Flow|<a name="mapasyncunordered"></a>@ref[mapAsyncUnordered](Source-or-Flow/mapAsyncUnordered.md)|Like `mapAsync` but @scala[`Future`] @java[`CompletionStage`] results are passed downstream as they arrive regardless of the order of the elements that triggered them.|
 
 ## Timer driven operators
@@ -510,6 +511,7 @@ For more background see the @ref[Error Handling in Streams](../stream-error.md) 
 * [logWithMarker](Source-or-Flow/logWithMarker.md)
 * [map](Source-or-Flow/map.md)
 * [mapAsync](Source-or-Flow/mapAsync.md)
+* [mapAsyncPartitioned](Source-or-Flow/mapAsyncPartitioned.md)
 * [mapAsyncUnordered](Source-or-Flow/mapAsyncUnordered.md)
 * [mapConcat](Source-or-Flow/mapConcat.md)
 * [mapError](Source-or-Flow/mapError.md)

--- a/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
+++ b/akka-docs/src/test/java/jdocs/actor/ActorDocTest.java
@@ -841,7 +841,8 @@ public class ActorDocTest extends AbstractJavaTest {
         // using timeout from above
         CompletableFuture<Object> future2 = ask(actorB, "another request", t).toCompletableFuture();
 
-        CompletableFuture<Result> transformed = future1.thenCombine(future2, (x, s) -> new Result((String) x, (String) s));
+        CompletableFuture<Result> transformed =
+            future1.thenCombine(future2, (x, s) -> new Result((String) x, (String) s));
 
         pipe(transformed, system.dispatcher()).to(actorC);
         // #ask-pipe

--- a/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapAsyncs.java
+++ b/akka-docs/src/test/java/jdocs/stream/operators/sourceorflow/MapAsyncs.java
@@ -6,11 +6,15 @@ package jdocs.stream.operators.sourceorflow;
 
 import akka.NotUsed;
 import akka.actor.ActorSystem;
+import akka.japi.function.Function;
 import akka.pattern.Patterns;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 
 import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -24,13 +28,13 @@ public class MapAsyncs {
   // #mapasync-concurrent
   // #mapasyncunordered
 
-  private final Source<Event, NotUsed> events =
+  private final Source<Event, NotUsed> events = // ...
+      // #mapasync-strict-order
+      // #mapasync-concurrent
+      // #mapasyncunordered
       Source.fromIterator(() -> Stream.iterate(1, i -> i + 1).iterator())
           .throttle(1, Duration.ofMillis(50))
-          .map(Event::new);
-  // #mapasync-strict-order
-  // #mapasync-concurrent
-  // #mapasyncunordered
+          .map(PlainEvent::new);
 
   private final ActorSystem system = ActorSystem.create("mapAsync-operator-examples");
 
@@ -52,9 +56,9 @@ public class MapAsyncs {
           Patterns.after(
               Duration.ofMillis(500),
               system,
-              () -> CompletableFuture.completedFuture(in.sequenceNumber));
+              () -> CompletableFuture.completedFuture(in.sequenceNumber()));
     } else {
-      cs = CompletableFuture.completedFuture(in.sequenceNumber);
+      cs = CompletableFuture.completedFuture(in.sequenceNumber());
     }
     return cs.thenApply(
         i -> {
@@ -99,20 +103,153 @@ public class MapAsyncs {
     // #mapasyncunordered
   }
 
-  public static void main(String[] args) {
-    new MapAsyncs().run();
+  private void runPartitioned() {
+    // #mapAsyncPartitioned
+    Source<EntityEvent, NotUsed> eventsForEntities = // ...
+        // #mapAsyncPartitioned
+        Source.fromIterator(() -> Stream.iterate(1, i -> i + 1).iterator())
+            .throttle(1, Duration.ofMillis(1))
+            .statefulMapConcat(
+                () -> {
+                  final HashMap<Integer, Integer> countsPerEntity = new HashMap<Integer, Integer>();
+
+                  return (n) -> {
+                    int entityId;
+
+                    if (random.nextBoolean() || countsPerEntity.isEmpty()) {
+                      entityId = random.nextInt(n);
+                    } else {
+                      int m = random.nextInt(countsPerEntity.size()) + 1;
+                      Iterator<Integer> keysIterator = countsPerEntity.keySet().iterator();
+
+                      Integer selected = Integer.valueOf(-1);
+                      int i = 0;
+                      while (keysIterator.hasNext() && i < m) {
+                        if (i == m - 1) {
+                          selected = keysIterator.next();
+                        } else {
+                          keysIterator.next();
+                        }
+                        i++;
+                      }
+                      entityId = selected.intValue();
+                    }
+
+                    if (entityId < 0) {
+                      throw new AssertionError("entityId should be non-negative, was " + entityId);
+                    }
+
+                    int seqNr =
+                        countsPerEntity
+                                .getOrDefault(Integer.valueOf(entityId), Integer.valueOf(0))
+                                .intValue()
+                            + 1;
+                    countsPerEntity.put(Integer.valueOf(entityId), Integer.valueOf(seqNr));
+
+                    return Collections.singletonList(new EntityEvent(entityId, seqNr));
+                  };
+                })
+            .take(1000);
+
+    // #mapAsyncPartitioned
+    Function<EntityEvent, Integer> partitioner =
+        (event) -> {
+          Integer partition = Integer.valueOf(event.entityId);
+          System.out.println("Assigned event " + event + " to partition " + event.entityId);
+          return partition;
+        };
+
+    eventsForEntities
+        .statefulMapConcat(
+            () -> {
+              final int[] offset = new int[1]; // trick to close over an int...
+              offset[0] = 0;
+
+              return (event) -> {
+                System.out.println(
+                    "Received event " + event + " at offset " + offset[0] + " from message broker");
+                offset[0]++;
+                return Collections.singletonList(event);
+              };
+            })
+        .mapAsyncPartitioned(
+            10,  // parallelism
+            1,   // perPartition
+            partitioner,
+            (event, partition) -> {
+              System.out.println("Processing event " + event + " from partition " + partition);
+
+              CompletionStage<String> cs;
+              CompletableFuture<String> cf =
+                  CompletableFuture.completedFuture(
+                      partition.toString() + "-" + event.sequenceNumber());
+              if (random.nextBoolean()) {
+                cs = Patterns.after(Duration.ofMillis(random.nextInt(1000)), system, () -> cf);
+              } else {
+                cs = cf;
+              }
+
+              return cs.thenApply(
+                  s -> {
+                    System.out.println("Completed processing " + s);
+                    return s;
+                  });
+            })
+        .map(in -> "`mapAsyncPartitioned` emitted " + in)
+        .runWith(Sink.foreach(str -> System.out.println(str)), system);
+    // #mapAsyncPartitioned
   }
 
-  static class Event {
-    public final int sequenceNumber;
+  public static void main(String[] args) {
+    MapAsyncs mapAsyncs = new MapAsyncs();
+    if (args[0].equals("partitioned")) {
+      mapAsyncs.runPartitioned();
+    } else if (args[0].equals("strict")) {
+      mapAsyncs.runStrictOrder();
+    } else if (args[0].equals("unordered")) {
+      mapAsyncs.runUnordered();
+    } else {
+      mapAsyncs.run();
+    }
+  }
 
-    public Event(int sequenceNumber) {
-      this.sequenceNumber = sequenceNumber;
+  static interface Event {
+    public int sequenceNumber();
+  }
+
+  static class PlainEvent implements Event {
+    public final int _sequenceNumber;
+
+    public PlainEvent(int sequenceNumber) {
+      this._sequenceNumber = sequenceNumber;
+    }
+
+    public int sequenceNumber() {
+      return _sequenceNumber;
     }
 
     @Override
     public String toString() {
-      return "Event(" + sequenceNumber + ')';
+      return "Event(" + _sequenceNumber + ')';
+    }
+  }
+
+  static class EntityEvent implements Event {
+    public final int entityId;
+    public final int _sequenceNumber;
+
+    public EntityEvent(int entityId, int sequenceNumber) {
+      this.entityId = entityId;
+      this._sequenceNumber = sequenceNumber;
+    }
+
+    public int sequenceNumber() {
+      return _sequenceNumber;
+    }
+
+    @Override
+    public String toString() {
+      return "EntityEvent(" + entityId + ", " + _sequenceNumber + ")";
     }
   }
 }

--- a/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapAsyncs.scala
+++ b/akka-docs/src/test/scala/docs/stream/operators/sourceorflow/MapAsyncs.scala
@@ -10,6 +10,7 @@ import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.util.Timeout
 
+import scala.collection.immutable
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -19,7 +20,16 @@ import scala.util.Random
  *
  */
 object CommonMapAsync {
-  case class Event(sequenceNumber: Int)
+  sealed trait Event {
+    def sequenceNumber: Int
+  }
+
+  object Event {
+    def apply(sequenceNumber: Int): PlainEvent = PlainEvent(sequenceNumber)
+  }
+
+  case class PlainEvent(sequenceNumber: Int) extends Event
+  case class EntityEvent(entityId: Int, sequenceNumber: Int) extends Event
 
   implicit val sys: ActorSystem = ActorSystem("mapAsync-stream")
   implicit val exCtx: ExecutionContextExecutor = sys.dispatcher
@@ -113,4 +123,80 @@ object MapAsyncUnordered extends App {
     // #mapasyncunordered
     .runWith(Sink.ignore)
 
+}
+
+object MapAsyncPartitioned extends App {
+  import CommonMapAsync._
+
+  // #mapAsyncPartitioned
+  val eventsForEntities: Source[EntityEvent, NotUsed] = // ...
+    // #mapAsyncPartitioned
+    Source.fromIterator { () => Iterator.from(1) }
+      .throttle(1, 1.millis)
+      .statefulMapConcat { () =>
+        var countsPerEntity = immutable.Map.empty[Int, Int]
+
+        { n =>
+          val entityId =
+            if (Random.nextBoolean || countsPerEntity.isEmpty) Random.nextInt(n)
+            else {
+              val m = Random.nextInt(countsPerEntity.size) + 1
+              countsPerEntity.keys.iterator
+                .take(m)
+                .drop(m - 1)
+                .next()
+            }
+          val seqNr = countsPerEntity.getOrElse(entityId, 0) + 1
+          countsPerEntity = countsPerEntity + (entityId -> seqNr)
+          List(EntityEvent(entityId, seqNr))
+        }
+      }
+      .take(1000)
+  
+  // #mapAsyncPartitioned
+  val partitioner: EntityEvent => Int = { event =>
+    val partition = event.entityId
+    println(s"Assigned event $event to partition $partition")
+    partition
+  }
+
+  eventsForEntities
+    .statefulMapConcat { () =>
+      var offset = 0
+
+      { event =>
+        println(s"Received event $event at offset $offset from message broker")
+        offset += 1
+        List(event)
+      }
+    }
+    .mapAsyncPartitioned(10, 1)(partitioner) { (event, partition) =>
+      println(s"Processing event $event from partition $partition")
+
+      val fut = Future.successful(s"$partition-${event.sequenceNumber}")
+      val result =
+        if (Random.nextBoolean) {
+          val delay = Random.nextInt(1000).millis
+          akka.pattern.after(delay)(fut)
+        } else {
+          fut
+        }
+
+      result.map { x =>
+        println(s"Completed processing $x")
+        x
+      }
+    }
+    .map { in =>
+      println(s"`mapAsyncPartitioned` emitted $in")
+    }
+    // #mapAsyncPartitioned
+    .runWith(Sink.ignore)
+    .flatMap { _ =>
+      // give the printlns a chance to print
+      akka.pattern.after(1.second)(Future.unit)
+    }.foreach { _ =>
+      System.out.flush()
+      sys.terminate()
+    }
 }

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/ChainedBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/ChainedBufferSpec.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl
+
+import akka.stream.testkit.StreamSpec
+import scala.annotation.tailrec
+import org.scalatest.compatible.Assertion
+
+class ChainedBufferSpec extends StreamSpec {
+  val doNothing: Any => Unit = _ => ()
+
+  val random = scala.util.Random.nextInt(16)
+  val headCapacity = random / 4 + 1
+  val tailCapacity = random % 4 + 1
+
+  def buffers[T](callback: T => Unit = doNothing): (Buffer[T], Buffer[T], ChainedBuffer[T]) = {
+    val headBuffer = FixedSizeBuffer[T](headCapacity)
+    val tailBuffer = FixedSizeBuffer[T](tailCapacity)
+
+    (headBuffer, tailBuffer, new ChainedBuffer(headBuffer, tailBuffer, callback))
+  }
+
+  s"ChainedBuffer of head-capacity $headCapacity and tail-capacity $tailCapacity" must {
+    s"have capacity of $headCapacity + $tailCapacity" in {
+      val (_, _, chainedBuffer) = buffers[Int]()
+
+      chainedBuffer.capacity shouldBe (headCapacity + tailCapacity)
+    }
+
+    "report empty until first enqueue" in {
+      val (_, _, chainedBuffer) = buffers[Int]()
+
+      chainedBuffer.isEmpty shouldBe true
+
+      chainedBuffer.enqueue(1)
+
+      chainedBuffer.isEmpty shouldBe false
+    }
+
+    "not report full until capacity elements have been enqueued" in {
+      val (_, _, chainedBuffer) = buffers[Int]()
+
+      (0 until chainedBuffer.capacity).foreach { n =>
+        assert(!chainedBuffer.isFull, s"buffer was full after $n enqueues")
+        chainedBuffer.enqueue(n)
+      }
+
+      chainedBuffer.isFull shouldBe true
+    }
+
+    "not report empty unless as many drops as enqueues have been performed" in {
+      val (_, _, chainedBuffer) = buffers[Int]()
+      var enqueues = 0
+      var drops = 0
+
+      @tailrec
+      def iter: Assertion = {
+        assert(enqueues >= drops, "BAD TEST: should not drop more than enqueue!")
+
+        if (enqueues == drops) {
+          assert(chainedBuffer.isEmpty, s"buffer was not empty after $enqueues enqueues and $drops drops")
+        } else {
+          assert(!chainedBuffer.isEmpty, s"buffer was empty after $enqueues enqueues and $drops drops")
+        }
+
+        if (enqueues > 16 && drops > 16) succeed
+        else {
+          if (chainedBuffer.isEmpty || (!chainedBuffer.isFull && scala.util.Random.nextBoolean())) {
+            chainedBuffer.enqueue(enqueues)
+            enqueues += 1
+          } else {
+            if (scala.util.Random.nextBoolean()) chainedBuffer.dropHead()
+            else chainedBuffer.dropTail()
+
+            drops += 1
+          }
+
+          iter
+        }
+      }
+
+      iter
+    }
+
+    "drop head" in {
+      var hitWith = -1
+      val (head, tail, chainedBuffer) = buffers[Int] { hitWith = _ }
+      (0 until chainedBuffer.capacity).foreach(chainedBuffer.enqueue)
+      hitWith = -1
+      chainedBuffer.isFull shouldBe true
+
+      chainedBuffer.dropHead()
+
+      hitWith shouldBe headCapacity
+      chainedBuffer.isFull shouldBe false
+      assert(head.isFull, "head buffer should still be full")
+      assert(!tail.isFull, "tail buffer should not be full")
+      (1 until chainedBuffer.capacity).foreach { i =>
+        chainedBuffer.dequeue() shouldBe i
+      }
+      chainedBuffer.isEmpty shouldBe true
+    }
+
+    "drop tail" in {
+      var hitWith = -1
+      val (head, tail, chainedBuffer) = buffers[Int] { hitWith = _ }
+      (0 until chainedBuffer.capacity).foreach(chainedBuffer.enqueue)
+      hitWith = -1
+      chainedBuffer.isFull shouldBe true
+
+      chainedBuffer.dropTail()
+
+      hitWith shouldBe -1
+      chainedBuffer.isFull shouldBe false
+      assert(head.isFull, "head buffer should still be full")
+      assert(!tail.isFull, "tail buffer should not be full")
+      (0 until chainedBuffer.capacity - 1).foreach { i =>
+        chainedBuffer.dequeue() shouldBe i
+      }
+      chainedBuffer.isEmpty shouldBe true
+    }
+
+    "dequeue" in {
+      var sum = 0
+      val (head, _, chainedBuffer) = buffers[Int] { sum += _ }
+      sum shouldBe 0
+      val numEnqueues = 1 + scala.util.Random.nextInt(chainedBuffer.capacity)
+      (1 to numEnqueues).foreach(chainedBuffer.enqueue)
+
+      // sum of 1 .. numEnqueues
+      val allSum = (numEnqueues * (numEnqueues + 1) / 2)
+
+      if (numEnqueues < headCapacity) {
+        head.isFull shouldBe false
+        sum shouldBe allSum
+      } else {
+        head.isFull shouldBe true
+        sum shouldBe (headCapacity * (headCapacity + 1) / 2)
+      }
+
+      var preSum = sum
+      (1 to numEnqueues).foreach { i =>
+        chainedBuffer.dequeue() shouldBe i
+        if (i > (numEnqueues - headCapacity)) {
+          sum shouldBe allSum
+        } else {
+          sum shouldBe preSum + (i + headCapacity)
+          preSum = sum
+        }
+      }
+    }
+  }
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/impl/PartitionedBufferSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl
+
+import akka.stream.testkit.StreamSpec
+
+class PartitionedBufferSpec extends StreamSpec {
+  val doNothing: Any => Unit = _ => ()
+
+  val linearCapacity = scala.util.Random.nextInt(32) + 1
+  val capacityPerPartition = scala.util.Random.nextInt((linearCapacity / 2).max(1)) + 1
+  val numPartitions = {
+    val q = linearCapacity / capacityPerPartition
+    if (q * capacityPerPartition == linearCapacity) q else q + 1
+  }
+
+  def makePartitionBuffer[T](hardCapacity: Int, callback: T => Unit): Buffer[T] =
+    if (capacityPerPartition < hardCapacity) {
+      val headBuffer = FixedSizeBuffer[T](capacityPerPartition)
+      val tailBuffer = new BoundedBuffer.DynamicQueue[T](hardCapacity - capacityPerPartition)
+
+      new ChainedBuffer(headBuffer, tailBuffer, callback)
+    } else {
+      FixedSizeBuffer[T](hardCapacity)
+    }
+
+  def buffer(callback: Int => Unit = doNothing): PartitionedBuffer[Int, Int] =
+    new PartitionedBuffer(linearBuffer = Buffer(linearCapacity, 32), partitioner = { x =>
+      (x % numPartitions).abs
+    }, makePartitionBuffer = { (k, c) =>
+      callback(k); makePartitionBuffer(c, doNothing)
+    })
+
+  s"PartitionedBuffer of capacity $linearCapacity and per-partition capacity $capacityPerPartition" must {
+    s"have capacity $linearCapacity" in {
+      val partitionBuffer = buffer()
+
+      partitionBuffer.capacity shouldBe linearCapacity
+    }
+
+    "partition enqueued elements" in {
+      val partitionBuffer = buffer()
+
+      val elem = scala.util.Random.nextInt()
+      partitionBuffer.enqueue(elem)
+
+      partitionBuffer.peekPartition(partitionBuffer.partitioner(elem)) should contain(elem)
+    }
+
+    "support dropHead'ing from partition sub-buffers" in {
+      val partitionBuffer = buffer()
+
+      val elem = scala.util.Random.nextInt()
+      partitionBuffer.enqueue(elem)
+      val key = partitionBuffer.partitioner(elem)
+      val enqueueSecond = linearCapacity > 1
+      val nextElem = {
+        val x = elem + numPartitions
+        if (x > elem) x else x - numPartitions
+      }
+
+      if (enqueueSecond) {
+        partitionBuffer.enqueue(nextElem)
+      }
+
+      partitionBuffer.dropOnlyPartitionHead(key)
+
+      partitionBuffer.dequeue() shouldBe elem
+      partitionBuffer.peekPartition(key) should be(if (enqueueSecond) Some(nextElem) else None)
+    }
+
+    "dequeue from partition sub-buffers when dequeueing" in {
+      val partitionBuffer = buffer()
+
+      val elem = scala.util.Random.nextInt()
+      partitionBuffer.enqueue(elem)
+      val key = partitionBuffer.partitioner(elem)
+      val enqueueSecond = linearCapacity > 1 && scala.util.Random.nextBoolean()
+      val nextElem = {
+        val x = elem + numPartitions
+        if (x > elem) x else x - numPartitions
+      }
+
+      if (enqueueSecond) {
+        partitionBuffer.enqueue(nextElem)
+      }
+
+      partitionBuffer.dequeue() shouldBe elem
+      partitionBuffer.peekPartition(key) shouldNot contain(elem)
+    }
+
+    "clear sub-buffers when clearing" in {
+      val partitionBuffer = buffer()
+
+      val elem = scala.util.Random.nextInt()
+      partitionBuffer.enqueue(elem)
+      val key = partitionBuffer.partitioner(elem)
+
+      partitionBuffer.clear()
+
+      partitionBuffer.isEmpty shouldBe true
+      partitionBuffer.peekPartition(key) shouldBe empty
+    }
+
+    "not support dropTail" in {
+      val partitionBuffer = buffer()
+
+      an[UnsupportedOperationException] shouldBe thrownBy {
+        partitionBuffer.dropTail()
+      }
+    }
+  }
+}

--- a/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
+++ b/akka-stream-tests/src/test/scala/akka/stream/scaladsl/FlowMapAsyncPartitionedSpec.scala
@@ -1,0 +1,477 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.scaladsl
+
+import akka.stream.{ ActorAttributes, Supervision }
+import akka.stream.testkit._
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.{ TestLatch, TestProbe }
+import org.scalatest.compatible.Assertion
+
+import scala.concurrent.{ Await, Future, Promise }
+import scala.concurrent.duration._
+import scala.util.{ Left, Right }
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.LinkedBlockingQueue
+
+class FlowMapAsyncPartitionedSpec extends StreamSpec {
+  import Utils.TE
+
+  "A Flow with mapAsyncPartitioned" must {
+    "produce future elements" in {
+      import system.dispatcher
+
+      val c = TestSubscriber.manualProbe[Int]()
+      Source(1 to 3)
+        .mapAsyncPartitioned(4, 2)(_ % 2) { (elem, _) =>
+          Future(elem)
+        }
+        .runWith(Sink.fromSubscriber(c))
+
+      val sub = c.expectSubscription()
+      sub.request(2)
+      c.expectNext(1)
+      c.expectNext(2)
+      c.expectNoMessage(200.millis)
+      sub.request(2)
+      c.expectNext(3)
+      c.expectComplete()
+    }
+  }
+
+  "produce elements in order of ingestion regardless of future completion order" in {
+    val c = TestSubscriber.manualProbe[Int]()
+    val promises = (0 until 50).map { _ =>
+      Promise[Int]()
+    }.toArray
+
+    Source(0 until 50)
+      .mapAsyncPartitioned(25, 3)(_ % 7) { (elem, _) =>
+        promises(elem).future
+      }
+      .to(Sink.fromSubscriber(c))
+      .run()
+
+    val sub = c.expectSubscription()
+    sub.request(1000)
+
+    // completes all the promises in random order
+    @annotation.tailrec
+    def iter(completed: Int, i: Int): Unit =
+      if (completed != promises.size) {
+        if (promises(i).isCompleted) iter(completed, (i + 1) % promises.size)
+        else {
+          promises(i).success(i)
+          iter(completed + 1, scala.util.Random.nextInt(promises.size))
+        }
+      }
+
+    iter(0, scala.util.Random.nextInt(promises.size))
+
+    (0 until 50).foreach { i =>
+      c.expectNext(i)
+    }
+    c.expectComplete()
+  }
+
+  "not run more futures than overall parallelism" in {
+    import system.dispatcher
+
+    val probe = TestProbe()
+    val c = TestSubscriber.manualProbe[Int]()
+
+    // parallelism, perPartition, and partitioner chosen to maximize number of futures
+    //  in-flight
+    val maxParallelism = (Runtime.getRuntime.availableProcessors / 2).max(3).min(8)
+    Source(1 to 22)
+      .mapAsyncPartitioned(maxParallelism, 2)(_ % 22) { (elem, _) =>
+        Future {
+          probe.ref ! elem
+          elem
+        }
+      }
+      .to(Sink.fromSubscriber(c))
+      .run()
+
+    val sub = c.expectSubscription()
+    probe.expectNoMessage(100.millis)
+    sub.request(1)
+    probe.receiveN(maxParallelism + 1) should contain theSameElementsAs (1 to (maxParallelism + 1))
+    probe.expectNoMessage(100.millis)
+    sub.request(2)
+    probe.receiveN(2) should contain theSameElementsAs (2 to 3).map(_ + maxParallelism)
+    probe.expectNoMessage(100.millis)
+    sub.request(10)
+    probe.receiveN(10) should contain theSameElementsAs (4 to 13).map(_ + maxParallelism)
+    probe.expectNoMessage(200.millis)
+  }
+
+  "signal future already failed" in {
+    import system.dispatcher
+
+    val latch = TestLatch(1)
+    val c = TestSubscriber.manualProbe[Int]()
+    Source(1 to 5)
+      .mapAsyncPartitioned(4, 2)(_ % 3) { (elem, _) =>
+        if (elem == 3) Future.failed[Int](new TE("BOOM TRES!"))
+        else
+          Future {
+            Await.ready(latch, 10.seconds)
+            elem
+          }
+      }
+      .to(Sink.fromSubscriber(c))
+      .run()
+
+    val sub = c.expectSubscription()
+    sub.request(10)
+    c.expectError().getMessage shouldBe "BOOM TRES!"
+    latch.countDown()
+  }
+
+  "signal future failure" in {
+    import system.dispatcher
+
+    val latch = TestLatch(1)
+    val c = TestSubscriber.manualProbe[Int]()
+
+    Source(1 to 5)
+      .mapAsyncPartitioned(4, 2)(_ % 3) { (elem, _) =>
+        Future {
+          if (elem == 3) throw new TE("BOOM TROIS!")
+          else {
+            Await.ready(latch, 10.seconds)
+            elem
+          }
+        }
+      }
+      .to(Sink.fromSubscriber(c))
+      .run()
+
+    val sub = c.expectSubscription()
+    sub.request(10)
+    c.expectError().getMessage shouldBe "BOOM TROIS!"
+    latch.countDown()
+  }
+
+  "signal future failure asap" in {
+    val latch = TestLatch(1)
+    val done =
+      Source(1 to 5)
+        .map { elem =>
+          if (elem == 1) elem
+          else {
+            // Slow the upstream after the first
+            Await.ready(latch, 10.seconds)
+            elem
+          }
+        }
+        .mapAsyncPartitioned(4, 2)(_ % 3) { (elem, _) =>
+          if (elem == 1) Future.failed(new TE("BOOM EIN!"))
+          else Future.successful(elem)
+        }
+        .runWith(Sink.ignore)
+
+    intercept[TE] {
+      Await.result(done, remainingOrDefault)
+    }.getMessage shouldBe "BOOM EIN!"
+    latch.countDown()
+  }
+
+  "fail ASAP midstream when stop supervision is in place" in {
+    import scala.collection.immutable
+    import system.dispatcher
+
+    val promises = (0 until 6).map(_ => Promise[Int]()).toArray
+    val probe =
+      Source(0 until 6)
+        .mapAsyncPartitioned(5, 1)(_ % 7) { (elem, _) =>
+          promises(elem).future.map(n => ('A' + n).toChar)
+        }
+        .runWith(TestSink.probe)
+
+    probe.request(100)
+    val failure = new Exception("BOOM två")
+    scala.util.Random.shuffle((0 until 6): immutable.Seq[Int]).foreach { n =>
+      if (n == 2) promises(n).failure(failure)
+      else promises(n).success(n)
+    }
+
+    // we don't know when the third promise will be failed
+    probe.expectNextOrError() match {
+      case Left(ex) => ex.getMessage shouldBe failure.getMessage // fine, error can overtake elements
+      case Right('A') =>
+        probe.expectNextOrError() match {
+          case Left(ex) => ex.getMessage shouldBe failure.getMessage // fine, error can overtake elements
+          case Right('B') =>
+            probe.expectNextOrError() match {
+              case Left(ex) => ex.getMessage shouldBe failure.getMessage // fine, error can overtake elements
+              case Right(n) => fail(s"stage should have failed rather than emit $n")
+            }
+
+          case unexpected => fail(s"unexpected $unexpected")
+        }
+
+      case unexpected => fail(s"unexpected $unexpected")
+    }
+  }
+
+  "drop failed elements midstream when resume supervision is in place" in {
+    import scala.collection.immutable
+    import system.dispatcher
+
+    val promises = (0 until 6).map(_ => Promise[Int]()).toArray
+    val elements =
+      Source(0 until 6)
+        .mapAsyncPartitioned(5, 1)(_ % 7) { (elem, _) =>
+          promises(elem).future.map(n => ('A' + n).toChar)
+        }
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(Sink.seq)
+
+    val failure = new Exception("BOOM TWEE!")
+    scala.util.Random.shuffle((0 until 6): immutable.Seq[Int]).foreach { n =>
+      if (n == 2) promises(n).failure(failure)
+      else promises(n).success(n)
+    }
+
+    elements.futureValue should contain theSameElementsInOrderAs "ABDEF"
+  }
+
+  "signal error when constructing future" in {
+    import system.dispatcher
+
+    val latch = TestLatch(1)
+    val c = TestSubscriber.manualProbe[Int]()
+
+    Source(1 to 5)
+      .mapAsyncPartitioned(4, 2)(_ % 2) { (elem, _) =>
+        if (elem == 3) throw new TE("BOOM TRE!")
+        else
+          Future {
+            Await.ready(latch, 10.seconds)
+            elem
+          }
+      }
+      .to(Sink.fromSubscriber(c))
+      .run()
+
+    val sub = c.expectSubscription()
+    sub.request(10)
+    c.expectError().getMessage shouldBe "BOOM TRE!"
+    latch.countDown()
+  }
+
+  "resume after failed future if resume supervision is in place" in {
+    import system.dispatcher
+
+    val elements =
+      Source(1 to 5)
+        .mapAsyncPartitioned(4, 1)(_ % 2) { (elem, _) =>
+          Future {
+            if (elem == 3) throw new TE("BOOM TRZY!")
+            else elem
+          }
+        }
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(Sink.seq)
+
+    elements.futureValue should contain theSameElementsInOrderAs Seq(1, 2, 4, 5)
+  }
+
+  "resume after already failed future if resume supervision is in place" in {
+    val expected =
+      Source(1 to 5)
+        .mapAsyncPartitioned(4, 2)(_ % 2) { (elem, _) =>
+          if (elem == 3) Future.failed(new TE("BOOM TRI!"))
+          else Future.successful(elem)
+        }
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(Sink.seq)
+
+    expected.futureValue should contain theSameElementsInOrderAs Seq(1, 2, 4, 5)
+  }
+
+  "resume after multiple failures if resume supervision is in place" in {
+    import system.dispatcher
+
+    val expected =
+      Source(1 to 10)
+        .mapAsyncPartitioned(4, 2)(_ % 3) { (elem, _) =>
+          if (elem % 4 < 3) {
+            val ex = new TE("BOOM!")
+            scala.util.Random.nextInt(3) match {
+              case 0 => Future.failed(ex)
+              case 1 => Future { throw ex }
+              case 2 => throw ex
+            }
+          } else Future.successful(elem)
+        }
+        .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
+        .runWith(Sink.seq)
+
+    expected.futureValue should contain theSameElementsInOrderAs (1 to 10).filter(_ % 4 == 3)
+  }
+
+  "ignore null-completed futures" in {
+    val shouldBeNull = {
+      val n = scala.util.Random.nextInt(10) + 1
+      (1 to n).foldLeft(Set.empty[Int]) { (set, _) =>
+        set + scala.util.Random.nextInt(10)
+      }
+    }
+    if (shouldBeNull.isEmpty) fail("should be at least one null")
+
+    val f: (Int, Int) => Future[String] = { (elem, _) =>
+      if (shouldBeNull(elem)) Future.successful(null)
+      else Future.successful(elem.toString)
+    }
+
+    val result =
+      Source(1 to 10).mapAsyncPartitioned(5, 2)(_ % 2)(f).runWith(Sink.seq)
+
+    result.futureValue should contain theSameElementsInOrderAs (1 to 10).filterNot(shouldBeNull).map(_.toString)
+  }
+
+  "handle cancel properly" in {
+    val pub = TestPublisher.manualProbe[Int]()
+    val sub = TestSubscriber.manualProbe[Int]()
+
+    Source
+      .fromPublisher(pub)
+      .mapAsyncPartitioned(4, 2)(_ % 2) { (elem, _) =>
+        Future.successful(elem)
+      }
+      .runWith(Sink.fromSubscriber(sub))
+
+    val upstream = pub.expectSubscription()
+    upstream.expectRequest()
+
+    sub.expectSubscription().cancel()
+
+    upstream.expectCancellation()
+  }
+
+  val maxParallelism = Runtime.getRuntime.availableProcessors.max(8)
+  val perPartition = scala.util.Random.nextInt(maxParallelism - 1) + 1
+  val numPartitions = 1 + (maxParallelism / perPartition)
+
+  s"not run more futures than allowed overall or per-partition ($maxParallelism, $perPartition, $numPartitions)" in {
+    val partitioner: Int => Int = _ % (1 + (maxParallelism / perPartition))
+
+    val globalCounter = new AtomicInteger
+    val partitionCounters =
+      (0 until numPartitions).map(_ -> new AtomicInteger).toMap: Map[Int, AtomicInteger]
+    val queue = new LinkedBlockingQueue[(Int, Promise[Int], Long)]
+
+    val timer = new Thread {
+      val maxDelay = 100000 // nanos
+
+      def delay(): Int =
+        scala.util.Random.nextInt(maxDelay) + 1
+
+      var count = 0
+
+      @annotation.tailrec
+      final override def run(): Unit = {
+        val cont =
+          try {
+            val (partition, promise, enqueued) = queue.take()
+            val wakeup = enqueued + delay()
+            while (System.nanoTime() < wakeup) {}
+            globalCounter.decrementAndGet()
+            partitionCounters(partition).decrementAndGet()
+            promise.success(count)
+            count += 1
+            true
+          } catch {
+            case _: InterruptedException => false
+          }
+
+        if (cont) run()
+      }
+    }
+    timer.start()
+
+    def deferred(partition: Int): Future[Int] =
+      if (globalCounter.incrementAndGet() > maxParallelism) {
+        Future.failed(new AssertionError("global parallelism exceeded"))
+      } else if (partitionCounters(partition).incrementAndGet() > perPartition) {
+        Future.failed(new AssertionError(s"partition parallelism for partition $partition exceeded"))
+      } else {
+        val p = Promise[Int]()
+        queue.offer((partition, p, System.nanoTime()))
+        p.future
+      }
+
+    try {
+      @volatile var lastElem = 0
+      val successes =
+        Source(1 to 10000)
+          .mapAsyncPartitioned(maxParallelism, perPartition)(partitioner) { (_, partition) =>
+            deferred(partition)
+          }
+          .filter { elem =>
+            if (elem == lastElem + 1) {
+              lastElem = elem
+              true
+            } else false
+          }
+          .runFold(0) { (c, e) =>
+            c + e
+          }
+
+      successes.futureValue shouldBe (5000 * 9999)
+    } finally {
+      timer.interrupt()
+    }
+  }
+
+  val thisWillNotStand = TE("this will not stand")
+
+  def deciderTest(f: (Boolean, Boolean) => Future[Boolean]): Assertion = {
+    val failCount = new AtomicInteger
+    val result =
+      Source(Seq(true, false))
+        .mapAsyncPartitioned(2, 1)(identity)(f)
+        .addAttributes(ActorAttributes.supervisionStrategy {
+          case x if x == thisWillNotStand =>
+            failCount.incrementAndGet()
+            Supervision.resume
+
+          case _ => Supervision.stop
+        })
+        .runWith(Sink.seq)
+
+    result.futureValue should contain only false
+    failCount.get() shouldBe 1
+  }
+
+  "not invoke the decider twice for the same failed future" in {
+    import system.dispatcher
+
+    deciderTest { (elem, _) =>
+      Future {
+        if (elem) throw thisWillNotStand
+        else elem
+      }
+    }
+  }
+
+  "not invoke the decider twice for the same pre-failed future" in {
+    deciderTest { (elem, _) =>
+      if (elem) Future.failed(thisWillNotStand)
+      else Future.successful(elem)
+    }
+  }
+
+  "not invoke the decider twice for the same failure to produce a future" in {
+    deciderTest { (elem, _) =>
+      if (elem) throw thisWillNotStand
+      else Future.successful(elem)
+    }
+  }
+}

--- a/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/Buffers.scala
@@ -7,6 +7,7 @@ package akka.stream.impl
 import java.{ util => ju }
 import akka.annotation.{ InternalApi, InternalStableApi }
 import akka.stream._
+import scala.collection.mutable
 
 /**
  * INTERNAL API
@@ -218,7 +219,7 @@ private[akka] object Buffer {
     }
   }
 
-  private final class DynamicQueue[T](override val capacity: Int) extends ju.LinkedList[T] with Buffer[T] {
+  private[impl] final class DynamicQueue[T](override val capacity: Int) extends ju.LinkedList[T] with Buffer[T] {
     override def used = size
     override def isFull = size == capacity
     override def nonEmpty = !isEmpty()
@@ -229,4 +230,155 @@ private[akka] object Buffer {
     override def dropHead(): Unit = remove()
     override def dropTail(): Unit = removeLast()
   }
+}
+
+/**
+ * INTERNAL API
+ * Represents a buffer which has two parts: head and tail.  Elements are dequeued from the head and enqueued into
+ * the head unless the head is full, in which case they are enqueued into the tail.  If there are elements in the
+ * tail, dequeueing will, in addition to dequeueing from the head, dequeue from the tail and enqueue that element
+ * into the head.
+ *
+ * It is also possible to arrange for a callback to execute whenever an element is enqueued into the head.
+ *
+ * This enables two potentially useful functionalities:
+ * * One can use a fixed-size buffer for the head and a dynamic queue as the tail while treating it as one buffer
+ * * One can use the head buffer as a collection of task slots to execute in some order
+ */
+@InternalApi
+private[impl] final class ChainedBuffer[T](headBuffer: Buffer[T], tailBuffer: Buffer[T], onEnqueueToHead: T => Unit)
+    extends Buffer[T] {
+  def capacity: Int = headBuffer.capacity + tailBuffer.capacity
+  def used: Int = headBuffer.used + tailBuffer.used
+  def isFull: Boolean = tailBuffer.isFull
+  def isEmpty: Boolean = headBuffer.isEmpty
+  def nonEmpty: Boolean = headBuffer.nonEmpty
+
+  def enqueue(elem: T): Unit =
+    if (headBuffer.isFull) tailBuffer.enqueue(elem)
+    else enqueueToHead(elem)
+
+  def dequeue(): T = {
+    val ret = headBuffer.dequeue()
+
+    if (tailBuffer.nonEmpty) {
+      val toHead = tailBuffer.dequeue()
+      enqueueToHead(toHead)
+    }
+
+    ret
+  }
+
+  def peek(): T = headBuffer.peek()
+
+  def clear(): Unit = {
+    headBuffer.clear()
+    tailBuffer.clear()
+  }
+
+  def dropHead(): Unit = dequeue()
+  def dropTail(): Unit =
+    if (tailBuffer.nonEmpty) tailBuffer.dropTail()
+    else headBuffer.dropTail()
+
+  private def enqueueToHead(elem: T): Unit = {
+    headBuffer.enqueue(elem)
+    onEnqueueToHead(elem)
+  }
+}
+
+/**
+ * INTERNAL API
+ * Represents a buffer which also partitions its elements into sub-buffers by key.  The sub-buffers may be individually
+ * dequeued without dequeueing from the overall buffer.  If an element A with partition key K is enqueued before
+ * element B with the same partition key K, then the following invariants hold after B has been enqueued:
+ *
+ * * if element A has not been dequeued, element B has not been dequeued (i.e. normal queue ordering holds)
+ * * if element B has been dequeued, element A has also been deqeued
+ * * if element A has not been dequeued from its sub-buffer, element B has not been dequeued from that sub-buffer
+ * * if element A has been dequeued, it was dequeued from the sub-buffer
+ */
+@InternalApi
+private[impl] final class PartitionedBuffer[K, V](
+    linearBuffer: Buffer[(K, V)],
+    val partitioner: V => K,
+    makePartitionBuffer: (K, Int) => Buffer[V])
+    extends Buffer[V] {
+  def capacity: Int = linearBuffer.capacity
+  def used: Int = linearBuffer.used
+  def isFull: Boolean = linearBuffer.isFull
+  def isEmpty: Boolean = linearBuffer.isEmpty
+  def nonEmpty: Boolean = linearBuffer.nonEmpty
+
+  def enqueue(elem: V): Unit = {
+    val key = partitioner(elem)
+    linearBuffer.enqueue(key -> elem)
+
+    partitionBuffers.get(key) match {
+      case Some(pbuf) => pbuf.enqueue(elem)
+      case None =>
+        val pbuf = makePartitionBuffer(key, linearBuffer.capacity)
+        partitionBuffers += (key -> pbuf)
+        pbuf.enqueue(elem)
+    }
+  }
+
+  def dequeue(): V = {
+    val (key, ret) = linearBuffer.dequeue()
+
+    partitionBuffers.get(key).foreach { pbuf =>
+      if (pbuf.peek() == ret) {
+        pbuf.dequeue()
+        if (pbuf.isEmpty) {
+          partitionBuffers.remove(key)
+        }
+      }
+    }
+
+    ret
+  }
+
+  def dropOnlyPartitionHead(key: K): Unit =
+    partitionBuffers.get(key).foreach { pbuf =>
+      pbuf.dequeue()
+      if (pbuf.isEmpty) {
+        partitionBuffers.remove(key)
+      }
+    }
+
+  def peek(): V = linearBuffer.peek()._2
+
+  def peekPartition(key: K): Option[V] = {
+    val pbuf = partitionBuffers.get(key)
+    pbuf.map(_.peek())
+  }
+
+  def clear(): Unit = {
+    linearBuffer.clear()
+    // ensure that all sub-buffers are cleared
+    partitionBuffers.foreachEntry { (_, buf) =>
+      buf.clear()
+    }
+    partitionBuffers.clear()
+  }
+
+  def dropHead(): Unit =
+    if (nonEmpty) {
+      val (key, head) = linearBuffer.dequeue()
+
+      partitionBuffers.get(key).foreach { pbuf =>
+        if (pbuf.peek() == head) {
+          pbuf.dropHead()
+          if (pbuf.isEmpty) {
+            partitionBuffers.remove(key)
+          }
+        }
+      }
+    }
+
+  def dropTail(): Unit =
+    // not entirely accurate, but this would require either a peekTail or a dequeue/enqueue cycle
+    throw new UnsupportedOperationException("cannot drop tail of a partitioned buffer")
+
+  private val partitionBuffers: mutable.Map[K, Buffer[V]] = mutable.Map.empty
 }

--- a/akka-stream/src/main/scala/akka/stream/impl/fusing/MapAsyncPartitioned.scala
+++ b/akka-stream/src/main/scala/akka/stream/impl/fusing/MapAsyncPartitioned.scala
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.impl.fusing
+
+import akka.stream._
+import akka.stream.ActorAttributes.SupervisionStrategy
+import akka.stream.Attributes.{ SourceLocation }
+import akka.stream.impl.{ Buffer => BufferImpl, PartitionedBuffer }
+import akka.stream.impl.Stages.DefaultAttributes
+import akka.stream.stage._
+import akka.util.OptionVal
+
+import scala.annotation.tailrec
+import scala.concurrent.Future
+import scala.util.{ Failure, Success, Try }
+import scala.util.control.NonFatal
+
+private[akka] object MapAsyncPartitioned {
+  def apply[In, Out, Partition](
+      parallelism: Int,
+      perPartition: Int,
+      partitioner: In => Partition,
+      f: (In, Partition) => Future[Out]): GraphStage[FlowShape[In, Out]] =
+    if (parallelism < 1) throw new IllegalArgumentException("parallelism must be at least 1")
+    else if (perPartition < 1) throw new IllegalArgumentException("perPartition must be at least 1")
+    else if (perPartition >= parallelism) {
+      // no point controlling per-partition, so just use a MapAsync, which has somewhat less overhead
+      val fin = { x: In =>
+        f(x, partitioner(x))
+      }
+      MapAsync(parallelism, fin)
+    } else new MapAsyncPartitioned(parallelism, perPartition, partitioner, f) {}
+
+  final class Holder[P, I, O](
+      var incoming: I,
+      var outgoing: Try[O],
+      val partition: P,
+      val cb: AsyncCallback[Holder[P, I, O]])
+      extends (Try[O] => Unit) {
+    private var cachedSupervisionDirective: OptionVal[Supervision.Directive] = OptionVal.None
+
+    def supervisionDirectiveFor(decider: Supervision.Decider, ex: Throwable): Supervision.Directive =
+      cachedSupervisionDirective match {
+        case OptionVal.Some(d) => d
+        case _ =>
+          val d = decider(ex)
+          cachedSupervisionDirective = OptionVal.Some(d)
+          d
+      }
+
+    def clearIncoming(): Unit = {
+      incoming = null.asInstanceOf[I]
+    }
+
+    def setOutgoing(t: Try[O]): Unit = {
+      outgoing = t
+    }
+
+    override def apply(t: Try[O]): Unit = {
+      setOutgoing(t)
+      cb.invoke(this)
+    }
+
+    override def toString: String = s"Holder($incoming, $outgoing, $partition)"
+  }
+
+  val NotYetThere = MapAsync.NotYetThere
+}
+
+private[akka] sealed abstract case class MapAsyncPartitioned[In, Out, Partition] private (
+    parallelism: Int,
+    perPartition: Int,
+    partitioner: In => Partition,
+    f: (In, Partition) => Future[Out])
+    extends GraphStage[FlowShape[In, Out]] {
+  import MapAsyncPartitioned._
+
+  private val in = Inlet[In]("MapAsyncPartitioned.in")
+  private val out = Outlet[Out]("MapAsyncPartitioned.out")
+
+  override def initialAttributes = DefaultAttributes.mapAsync and SourceLocation.forLambda(f)
+  override val shape = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) with InHandler with OutHandler {
+
+      lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
+      var buffer: PartitionedBuffer[Partition, Holder[Partition, In, Out]] = _
+
+      private val futureCB = getAsyncCallback[Holder[Partition, In, Out]] { holder =>
+        holder.outgoing match {
+          case Failure(ex) if holder.supervisionDirectiveFor(decider, ex) == Supervision.Stop => failStage(ex)
+          case _ =>
+            dropCompletedThenPushIfPossible(holder.partition)
+        }
+      }
+
+      override def preStart(): Unit = {
+        buffer = new PartitionedBuffer[Partition, Holder[Partition, In, Out]](
+          linearBuffer = BufferImpl(parallelism, inheritedAttributes),
+          partitioner = _.partition,
+          makePartitionBuffer = { (p, overflowCapacity) =>
+            import akka.stream.impl.{ BoundedBuffer, ChainedBuffer }
+            val tailCapacity = (overflowCapacity - perPartition).max(1)
+
+            new ChainedBuffer[Holder[Partition, In, Out]](
+              BufferImpl(perPartition, inheritedAttributes),
+              new BoundedBuffer.DynamicQueue(tailCapacity), {
+                holder =>
+                  // this will execute when the holder moves from the tail buffer to the head buffer (viz. ready to be
+                  //  scheduled).  This might be on enqueueing into the partitioned buffer, or it might be when
+                  //  the head of this partition is dropped after being completed.
+                  try {
+                    val future = f(holder.incoming, p)
+                    holder.clearIncoming()
+
+                    future.value match {
+                      case None    => future.onComplete(holder)(akka.dispatch.ExecutionContexts.parasitic)
+                      case Some(v) =>
+                        // future already completed, so don't schedule on dispatcher
+                        holder.setOutgoing(v)
+                        v match {
+                          case Failure(ex) if holder.supervisionDirectiveFor(decider, ex) == Supervision.Stop =>
+                            failStage(ex)
+
+                          case _ =>
+                            dropCompletedThenPushIfPossible(p)
+                        }
+                    }
+                  } catch {
+                    // executes if f throws, not a failed future
+                    case NonFatal(ex) =>
+                      val directive = holder.supervisionDirectiveFor(decider, ex)
+                      if (directive == Supervision.Stop) failStage(ex)
+                      else {
+                        holder.clearIncoming()
+                        if (holder.outgoing == NotYetThere) {
+                          holder.setOutgoing(Failure(ex))
+                          dropCompletedThenPushIfPossible(p)
+                        } else {
+                          failStage(
+                            new AssertionError("Should only get here if f throws, not if future was created", ex))
+                        }
+                      }
+                  }
+              })
+          })
+      }
+
+      override def onPull(): Unit = pushNextIfPossible()
+
+      override def onPush(): Unit = {
+        try {
+          val elem = grab(in)
+          val holder = new Holder[Partition, In, Out](
+            incoming = elem,
+            outgoing = NotYetThere,
+            partition = partitioner(elem),
+            cb = futureCB)
+
+          buffer.enqueue(holder)
+        } catch {
+          case NonFatal(ex) =>
+            if (decider(ex) == Supervision.Stop) failStage(ex)
+        }
+
+        pullIfNeeded()
+      }
+
+      override def onUpstreamFinish(): Unit = if (buffer.isEmpty) completeStage()
+
+      @tailrec
+      private def dropCompletedThenPushIfPossible(partition: Partition): Unit = {
+        val holderOpt = buffer.peekPartition(partition)
+        holderOpt match {
+          case None => pushNextIfPossible()
+          case Some(holder) =>
+            holder.outgoing match {
+              case NotYetThere                                                                              => pushNextIfPossible()
+              case Failure(NonFatal(ex)) if holder.supervisionDirectiveFor(decider, ex) == Supervision.Stop =>
+                // Could happen if this finds the failed future before the async callback runs
+                failStage(ex)
+
+              case Failure(NonFatal(_)) | Success(_) =>
+                buffer.dropOnlyPartitionHead(partition)
+                dropCompletedThenPushIfPossible(partition)
+
+              case Failure(ex) =>
+                // fatal exception in the buffer, not sure if this can actually happen, but for completeness...
+                throw ex
+            }
+        }
+      }
+
+      @tailrec
+      private def pushNextIfPossible(): Unit =
+        if (buffer.isEmpty) pullIfNeeded()
+        else if (buffer.peek().outgoing eq NotYetThere) pullIfNeeded()
+        else if (isAvailable(out)) {
+          // We peek instead of dequeue so that we can push out an element before
+          //  removing from the queue (since a dequeue or dropHead can cause re-entry)
+          val holder = buffer.peek()
+          holder.outgoing match {
+            case Success(elem) =>
+              if (elem != null) {
+                push(out, elem)
+                buffer.dropHead()
+                pullIfNeeded()
+              } else {
+                // elem is null
+                buffer.dropHead()
+                pullIfNeeded()
+                pushNextIfPossible()
+              }
+
+            case Failure(NonFatal(ex)) if holder.supervisionDirectiveFor(decider, ex) == Supervision.Stop =>
+              failStage(ex)
+
+            case Failure(NonFatal(_)) =>
+              buffer.dropHead()
+              pushNextIfPossible() // try the next element
+
+            case Failure(ex) => throw ex
+          }
+        }
+
+      private def pullIfNeeded(): Unit = {
+        if (isClosed(in) && buffer.isEmpty) completeStage()
+        else if (buffer.used < parallelism && !hasBeenPulled(in)) tryPull(in)
+        // else already pulled and waiting for next element
+      }
+
+      setHandlers(in, out, this)
+    }
+}

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Flow.scala
@@ -809,10 +809,51 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    *
-   * @see [[#mapAsyncUnordered]]
+   * @see [[#mapAsyncUnordered]] and [[#mapAsyncPartitioned]]
    */
   def mapAsync[T](parallelism: Int, f: function.Function[Out, CompletionStage[T]]): javadsl.Flow[In, T, Mat] =
     new Flow(delegate.mapAsync(parallelism)(x => f(x).toScala))
+
+  /**
+   * Transform this stream by partitioning elements based on the provided partitioner as they pass through this
+   * processing step and then applying a given `CompletionStage`-returning function to each element and its
+   * partition key.  The value of the returned future, if successful, will be emitted downstream.
+   *
+   * The number of CompletionStages running at any given time is bounded by the 'parallelism' and 'perPartition'
+   * values.  The CompletionStages may complete in any order, but the results are emitted in the same order as
+   * the corresponding elements were received.
+   *
+   * If the functions 'partitioner' or 'f' throw an exception, or if the 'CompletionStage' is completed with failure,
+   * supervision will be applied to determine a decision.  If the decision is [[akka.stream.Supervision#stop]], the
+   * stream will be completed with failure; otherwise the element will be dropped and the stream continues.
+   *
+   * The function 'partitioner' is always invoked on the elements in the order they arrive.
+   *
+   * The function 'f' is invoked on elements with the same partition key in the order they arrive.  The order of
+   * invocation of 'f' for elements with different partition keys is undefined and subject to factors including, but
+   * not limited to, the distribution of partition keys within the stream.
+   *
+   * '''Emits when''' the CompletionStage returned by the provided function 'f' finishes for the next element in
+   * sequence
+   *
+   * '''Backpressures when''' the number of elements for which no resulting CompletionStage has completed reaches the
+   * configured parallelism and the downstream backpressures or the first CompletionStage has not completed
+   *
+   * '''Completes when''' upstream completes and all CompletionStages have been completed and all elements have
+   * been emitted
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @see [[#mapAsync]] and [[#mapAsyncUnordered]]
+   */
+  def mapAsyncPartitioned[T, P](
+      parallelism: Int,
+      perPartition: Int,
+      partitioner: function.Function[Out, P],
+      f: BiFunction[Out, P, CompletionStage[T]]) =
+    new Flow(delegate.mapAsyncPartitioned(parallelism, perPartition)(x => partitioner(x)) { (x, p) =>
+      f(x, p).toScala
+    })
 
   /**
    * Transform this stream by applying the given function to each of the elements
@@ -843,7 +884,7 @@ final class Flow[In, Out, Mat](delegate: scaladsl.Flow[In, Out, Mat]) extends Gr
    *
    * '''Cancels when''' downstream cancels
    *
-   * @see [[#mapAsync]]
+   * @see [[#mapAsync]] and [[#mapAsyncPartitioned]]
    */
   def mapAsyncUnordered[T](parallelism: Int, f: function.Function[Out, CompletionStage[T]]): javadsl.Flow[In, T, Mat] =
     new Flow(delegate.mapAsyncUnordered(parallelism)(x => f(x).toScala))

--- a/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
+++ b/akka-stream/src/main/scala/akka/stream/javadsl/Source.scala
@@ -2488,6 +2488,15 @@ final class Source[Out, Mat](delegate: scaladsl.Source[Out, Mat]) extends Graph[
   def mapAsync[T](parallelism: Int, f: function.Function[Out, CompletionStage[T]]): javadsl.Source[T, Mat] =
     new Source(delegate.mapAsync(parallelism)(x => f(x).toScala))
 
+  def mapAsyncPartitioned[T, P](
+      parallelism: Int,
+      perPartition: Int,
+      partitioner: function.Function[Out, P],
+      f: BiFunction[Out, P, CompletionStage[T]]): javadsl.Source[T, Mat] =
+    new Source(delegate.mapAsyncPartitioned(parallelism, perPartition)(x => partitioner(x)) { (x, p) =>
+      f(x, p).toScala
+    })
+
   /**
    * Transform this stream by applying the given function to each of the elements
    * as they pass through this processing step. The function returns a `CompletionStage` and the

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1126,10 +1126,9 @@ trait FlowOps[+Out, +Mat] {
    * @see [[#mapAsync]] and [[#mapAsyncUnordered]]
    *
    * @param parallelism at most this many futures will be incomplete at any time
-   * @param perPartition
-   * @param partitioner
-   * @param f
-   * @return
+   * @param perPartition at most this many futures will be incomplete for a given partition key at any time
+   * @param partitioner function to generate a partition key
+   * @param f function to generate a Future
    */
   def mapAsyncPartitioned[T, P](parallelism: Int, perPartition: Int)(partitioner: Out => P)(
       f: (Out, P) => Future[T]): Repr[T] =

--- a/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
+++ b/akka-stream/src/main/scala/akka/stream/scaladsl/Flow.scala
@@ -1086,11 +1086,56 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    *
-   * @see [[#mapAsyncUnordered]]
+   * @see [[#mapAsyncUnordered]] and [[#mapAsyncPartitioned]]
    */
   def mapAsync[T](parallelism: Int)(f: Out => Future[T]): Repr[T] =
     if (parallelism == 1) mapAsyncUnordered[T](parallelism = 1)(f) // optimization for parallelism 1
     else via(MapAsync(parallelism, f))
+
+  /**
+   * Transform this stream by partitioning elements based on the provided partitioner as they
+   * pass through this step and then applying a given `Future`-returning function to each element
+   * and its partition key.  The value of the returned future, if successful, will be emitted
+   * downstream.
+   *
+   * The number of Futures running at any given time is bounded by the 'parallelism' and 'perPartition'
+   * values.  The futures may complete in any order, but the results are emitted in the same order
+   * as the corresponding elements were received.
+   *
+   * If the functions 'partitioner' or 'f' throw an exception, or the `Future` completes with failure,
+   * supervision will be applied to determine a decision.  If the decision is [[akka.stream.Supervision.Stop]]
+   * the stream will be stopped with failure; otherwise, the element will be dropped and the stream continues.
+   *
+   * The function 'partitioner' is always invoked on the elements in the order they arrive.
+   *
+   * The function 'f' is invoked on elements with the same partition key in the order they arrive.  The order
+   * of invocation of 'f' for elements with different partition keys is undefined and subject to factors
+   * including, but not limited to, the distribution of partition keys within the stream.
+   *
+   * Adheres to the [[ActorAttributes.SupervisionStrategy]] attribute.
+   *
+   * '''Emits when''' the Future returned by 'f' finishes for the next element in sequence
+   *
+   * '''Backpressures when''' the number of elements for which no resulting future has completed reaches the
+   * configured parallelism and the downstream backpressures
+   *
+   * '''Completes when''' upstream completes and all futures have been completed and all results have been emitted
+   *
+   * '''Cancels when''' downstream cancels
+   *
+   * @see [[#mapAsync]] and [[#mapAsyncUnordered]]
+   *
+   * @param parallelism at most this many futures will be incomplete at any time
+   * @param perPartition
+   * @param partitioner
+   * @param f
+   * @return
+   */
+  def mapAsyncPartitioned[T, P](parallelism: Int, perPartition: Int)(partitioner: Out => P)(
+      f: (Out, P) => Future[T]): Repr[T] =
+    if (parallelism == 1) mapAsyncUnordered[T](parallelism = 1) { elem =>
+      f(elem, partitioner(elem))
+    } else via(MapAsyncPartitioned(parallelism, perPartition, partitioner, f))
 
   /**
    * Transform this stream by applying the given function to each of the elements
@@ -1121,7 +1166,7 @@ trait FlowOps[+Out, +Mat] {
    *
    * '''Cancels when''' downstream cancels
    *
-   * @see [[#mapAsync]]
+   * @see [[#mapAsync]] and [[#mapAsyncPartitioned]]
    */
   def mapAsyncUnordered[T](parallelism: Int)(f: Out => Future[T]): Repr[T] = via(MapAsyncUnordered(parallelism, f))
 


### PR DESCRIPTION
A variant of `mapAsync` which limits overall parallelism and also parallelism per partition/bucket.  This is especially useful for a stream where order must be preserved (e.g. when reading from Kafka and committing offsets as the last step in the stream) when elements are sent (based on the element) to a component which doesn't backpressure but can eventually be overloaded (e.g. sending asks to a sharded entity) resulting in a failed future and a stream restart-backoff cycle.

For example:

```scala
// implicits omitted
val resolveEntityRef: KafkaMessage => EntityRef[Entity.Command] = ???
val decodeCommand: (KafkaMessage, ActorRef[Entity.Response]) => Entity.Command = ???

Flow[KafkaMessage]
  .mapAsyncPartitioned(40, 1)(resolveEntityRef) { (msg, entityRef) =>
    entityRef.ask(decodeCommand(msg, _))
  } : Flow[KafkaMessage, Entity.Response, NotUsed]
```

The flow will allow up to 40 asks to be in-flight at once, but only if no two are to the same entity.  This can be thought of as dynamically adjusting the parallelism in response to the distribution of a property of the incoming stream elements: if there's a run in the stream where 40+ consecutive messages are to the same entity, the effective parallelism will drop to one, effectively moving the one-at-a-time mailbox processing of the entity's underlying actor into the stream backpressure protocol.

No unordered version of this is provided: a `Partition` into substreams (e.g. by modular hash) into a merge is close enough and can be implemented.

The clustering of target entities can be observed in at least a couple of common situations:

* in IoT applications where devices sometimes have dramatic increases in the rate at which they "call home": for example a sensor might send a message when it observes a sufficiently large change and otherwise just send a periodic heartbeat with a summary of the net change since the last message sent.
* in data-processing applications fed by a change-data-capture process like Debezium, when first set up or when the CDC process discovers that its state doesn't match the DB (for instance write-ahead-log retention applied before the process could capture changes), the CDC process may elect to dump every record into the Kafka topic in key order.  Since the keys in the DB are likely to map to the target entity, this can result in a series of clumps of hundreds or more elements to the same entity: if the overall parallelism is high enough, this can saturate the entity's mailbox and lead to ask timeouts even when everything is healthy.

Relative to `mapAsync`, `mapAsyncPartitioned` has greater overhead (thus in situations where the per-partition limit wouldn't apply, this stage becomes `mapAsync`), but it makes it possible to increase parallelism and/or decrease future timeouts without incurring a risk that an unlucky run of input causes a failure and stream restart.