### PR TITLE
CompletionStage callbacks can prefer dispatcher over common ForkJoinPool

### DIFF
--- a/akka-actor-tests/src/test/scala/akka/util/DispatcherFutureConvertersSpec.scala
+++ b/akka-actor-tests/src/test/scala/akka/util/DispatcherFutureConvertersSpec.scala
@@ -1,0 +1,304 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.SECONDS
+import scala.concurrent.Await
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.concurrent.duration._
+
+import akka.Done
+import akka.testkit.AkkaSpec
+import org.scalatest.Assertion
+import org.scalatest.exceptions.TestFailedException
+
+class DispatcherFutureConvertersSpec extends AkkaSpec {
+  import DispatcherFutureConverters._
+
+  def threadComponents(): Array[String] = {
+    Thread.currentThread().getName().split('-')
+  }
+
+  "A Scala future should be convertible into a Java future which" must {
+    val defaultDispatcherPrefix = Await.result(Future {
+      threadComponents().dropRight(1)
+    }(system.dispatcher), 3.seconds)
+
+    def assertRunningOnDefaultDispatcher(): Assertion = {
+      threadComponents().take(defaultDispatcherPrefix.size).zipWithIndex.foldLeft(succeed) { (_, pair) =>
+        val (component, i) = pair
+        component shouldBe defaultDispatcherPrefix(i)
+      }
+    }
+
+    // Validate that the test is not itself running on the dispatcher
+    a[TestFailedException] shouldBe thrownBy(assertRunningOnDefaultDispatcher())
+
+    "propagate success" in {
+      val promise = Promise[String]()
+      val cs = asJava(promise.future, system.dispatcher)
+      val cf = cs.toCompletableFuture()
+
+      assert(!cf.isDone)
+      promise.success("Hello")
+      assert(cf.isDone)
+      cf.get() shouldBe "Hello"
+    }
+
+    "propagate failure" in {
+      val promise = Promise[String]()
+      val cs = asJava(promise.future, system.dispatcher)
+      val cf = cs.toCompletableFuture()
+      val ex = new RuntimeException("Boom")
+
+      promise.failure(ex)
+      assert(cf.isDone)
+      val wrapped = the[CompletionException] thrownBy (cf.join())
+      wrapped.getCause shouldBe ex
+    }
+
+    "support thenApply (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val cs = asJava(promise.future, system.dispatcher).thenApply(_ => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+        Done
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe Done
+    }
+
+    "support thenAccept (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val cs = asJava(promise.future, system.dispatcher).thenAccept(_ => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe null
+    }
+
+    "support thenRun (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val cs = asJava(promise.future, system.dispatcher).thenRun(() => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe null
+    }
+
+    "support thenCombine (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val other = CompletableFuture.completedStage[Integer](42)
+      val cs = asJava(promise.future, system.dispatcher).thenCombine(other, (x, y: Integer) => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+        s"$y $x"
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe "42 Hello"
+    }
+
+    "support thenAcceptBoth (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val other = CompletableFuture.completedStage[Integer](42)
+      val cs = asJava(promise.future, system.dispatcher).thenAcceptBoth[Integer](other, (_, _) => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe null
+    }
+
+    "support runAfterBoth (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val other = CompletableFuture.completedStage[Integer](42)
+      val cs = asJava(promise.future, system.dispatcher).runAfterBoth(other, () => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe null
+    }
+
+    "support applyToEither (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val other = new CompletableFuture[String]()
+      val cs = asJava(promise.future, system.dispatcher).applyToEither(other, x => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+        x.length
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe 5
+    }
+
+    "support acceptEither (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val other = new CompletableFuture[String]()
+      val cs = asJava(promise.future, system.dispatcher).applyToEither(other, x => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+        x.length
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe 5
+    }
+
+    "support runAfterEither (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val other = new CompletableFuture[String]()
+      val cs = asJava(promise.future, system.dispatcher).runAfterEither(other, () => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe null
+    }
+
+    "support thenCompose (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val cs = asJava(promise.future, system.dispatcher).thenCompose(x => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+        CompletableFuture.completedStage(s"$x 42")
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe "Hello 42"
+    }
+
+    "support whenComplete (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val cs = asJava(promise.future, system.dispatcher).whenComplete((_, _) => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe "Hello"
+    }
+
+    "support handle (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val cs = asJava(promise.future, system.dispatcher).handle((v, _) => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+        v.length
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.success("Hello")
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe 5
+    }
+
+    "support exceptionally (on the provided dispatcher)" in {
+      val promise = Promise[String]()
+      val latch = new CountDownLatch(1)
+      val cs = asJava(promise.future, system.dispatcher).exceptionally(e => {
+        assertRunningOnDefaultDispatcher()
+        latch.await(1, SECONDS)
+        e.getMessage
+      })
+      val cf = cs.toCompletableFuture()
+
+      promise.failure(new RuntimeException("Goodbye"))
+      assert(!cf.isDone)
+      latch.countDown()
+      cf.get() shouldBe "Goodbye"
+    }
+
+    "not allow completing the underlying promise from Java API" in {
+      val promise = Promise[String]()
+      val cf = asJava(promise.future, system.dispatcher).toCompletableFuture()
+
+      cf.getNow("not yet") shouldBe "not yet"
+      cf.complete("Java done")
+      cf.get() shouldBe "Java done"
+      assert(!promise.isCompleted)
+    }
+
+    "retain Scala completion when completing from Java after Scala" in {
+      val promise = Promise[String]()
+      val cf = asJava(promise.future, system.dispatcher).toCompletableFuture()
+
+      promise.success("Scala done")
+      cf.get() shouldBe "Scala done"
+      cf.complete("Java done")
+      cf.get() shouldBe "Scala done"
+    }
+
+    "retain Java completion when completing from Scala after Java" in {
+      val promise = Promise[String]()
+      val cf = asJava(promise.future, system.dispatcher).toCompletableFuture()
+
+      cf.complete("Java done")
+      cf.get() shouldBe "Java done"
+      promise.success("Scala done")
+      cf.get() shouldBe "Java done"
+    }
+  }
+}

--- a/akka-actor/src/main/scala/akka/util/DispatcherFutureConverters.scala
+++ b/akka-actor/src/main/scala/akka/util/DispatcherFutureConverters.scala
@@ -44,11 +44,15 @@ object DispatcherFutureConverters {
 
     def asJava(shiftTo: ExecutionContext): CompletionStage[T] = {
       val executor = shiftTo match {
-        case ece: ExecutionContextExecutor => ece
-        case _                             => ForkJoinPool.commonPool // match the Scala stdlib behavior when the provided EC isn't an Executor
+        case ece: ExecutionContextExecutor =>
+          ece // Not actually possible to reach normally, since we have a specific overload for ECE
+        case _ => ForkJoinPool.commonPool // match the Scala stdlib behavior when the provided EC isn't an Executor
       }
       DispatcherFutureConverters.asJava(scalaFuture, executor)
     }
+
+    def asJava(ece: ExecutionContextExecutor): CompletionStage[T] =
+      asJava(ece: Executor)
   }
 
   /** A minimal implementation of a Java CompletableFuture which shifts further computation onto the given

--- a/akka-actor/src/main/scala/akka/util/DispatcherFutureConverters.scala
+++ b/akka-actor/src/main/scala/akka/util/DispatcherFutureConverters.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2025 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.util
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+import java.util.function.{ Function => JFunction }
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import scala.concurrent.blocking
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+import java.util.function.Consumer
+import java.util.function.BiFunction
+import java.util.function.BiConsumer
+import scala.concurrent.ExecutionContextExecutor
+import java.util.concurrent.ForkJoinPool
+
+// This code is adapted from https://github.com/scala/scala/blob/2.13.x/src/library/scala/jdk/javaapi/FutureConverters.scala
+// and https://github.com/scala/scala/blob/2.13.x/src/library/scala/concurrent/impl/FutureConvertersImpl.scala
+/** Like the Scala stdlib FutureConverters, except shifts onto a provided execution context (rather than
+ *  the ForkJoin common pool as in the Scala stdlib) when converting to Java
+ */
+object DispatcherFutureConverters {
+  def asJava[T](f: Future[T], shiftTo: Executor): CompletionStage[T] =
+    f match {
+      // Not strictly safe as optimizations go, as there could be in a bizarre set of circumstances a Future[T] with CompletionStage[NotT]
+      case c: CompletionStage[T @unchecked] => c
+      case _ =>
+        val cf = new CF(f, shiftTo)
+        f.onComplete(cf)(ExecutionContext.parasitic)
+        cf
+    }
+
+  implicit class ScalaFutureOpsWithShiftTo[T](val scalaFuture: Future[T]) extends AnyVal {
+    def asJava(shiftTo: Executor): CompletionStage[T] =
+      DispatcherFutureConverters.asJava(scalaFuture, shiftTo)
+
+    def asJava(shiftTo: ExecutionContext): CompletionStage[T] = {
+      val executor = shiftTo match {
+        case ece: ExecutionContextExecutor => ece
+        case _                             => ForkJoinPool.commonPool // match the Scala stdlib behavior when the provided EC isn't an Executor
+      }
+      DispatcherFutureConverters.asJava(scalaFuture, executor)
+    }
+  }
+
+  /** A minimal implementation of a Java CompletableFuture which shifts further computation onto the given
+   *  Executor, rather than be parasitic on the completer of the wrapped Scala future.
+   *
+   *  Further "parasitic" computations on the returned CompletableFutures will behave as normal in Java
+   *  (viz. be parasitic).
+   */
+  private class CF[T](val wrapped: Future[T], shiftTo: Executor) extends CompletableFuture[T] with (Try[T] => Unit) {
+    override def apply(t: Try[T]): Unit =
+      t match {
+        case Success(v) => complete(v)
+        case Failure(e) => completeExceptionally(e)
+      }
+
+    override def thenApply[U](f: JFunction[_ >: T, _ <: U]): CompletableFuture[U] = thenApplyAsync(f, shiftTo)
+    override def thenAccept(f: Consumer[_ >: T]): CompletableFuture[Void] = thenAcceptAsync(f, shiftTo)
+    override def thenRun(f: Runnable): CompletableFuture[Void] = thenRunAsync(f, shiftTo)
+    override def thenCombine[U, V](
+        cs: CompletionStage[_ <: U],
+        f: BiFunction[_ >: T, _ >: U, _ <: V]): CompletableFuture[V] = thenCombineAsync(cs, f, shiftTo)
+
+    override def thenAcceptBoth[U](
+        cs: CompletionStage[_ <: U],
+        f: BiConsumer[_ >: T, _ >: U]): CompletableFuture[Void] = thenAcceptBothAsync(cs, f, shiftTo)
+
+    override def runAfterBoth(cs: CompletionStage[_], f: Runnable): CompletableFuture[Void] =
+      runAfterBothAsync(cs, f, shiftTo)
+
+    override def applyToEither[U](cs: CompletionStage[_ <: T], f: JFunction[_ >: T, U]): CompletableFuture[U] =
+      applyToEitherAsync(cs, f, shiftTo)
+
+    override def acceptEither(cs: CompletionStage[_ <: T], f: Consumer[_ >: T]): CompletableFuture[Void] =
+      acceptEitherAsync(cs, f, shiftTo)
+
+    override def runAfterEither(cs: CompletionStage[_], f: Runnable): CompletableFuture[Void] =
+      runAfterEitherAsync(cs, f, shiftTo)
+
+    override def thenCompose[U](f: JFunction[_ >: T, _ <: CompletionStage[U]]): CompletableFuture[U] =
+      thenComposeAsync(f, shiftTo)
+
+    override def whenComplete(f: BiConsumer[_ >: T, _ >: Throwable]): CompletableFuture[T] =
+      whenCompleteAsync(f, shiftTo)
+
+    override def handle[U](f: BiFunction[_ >: T, Throwable, _ <: U]): CompletableFuture[U] =
+      handleAsync(f, shiftTo)
+
+    override def exceptionally(f: JFunction[Throwable, _ <: T]): CompletableFuture[T] = {
+      val cf = new CompletableFuture[T]
+      whenComplete((t, e) => { // implicitly shifts to shiftTo
+        if (e == null) cf.complete(t)
+        else {
+          val n: AnyRef = try {
+            f(e).asInstanceOf[AnyRef]
+          } catch {
+            case thr: Throwable =>
+              cf.completeExceptionally(thr)
+              this
+          }
+
+          if (n ne this) {
+            cf.complete(n.asInstanceOf[T])
+          } // else do nothing (already completed exceptionally)
+        }
+      })
+
+      cf
+    }
+
+    /** @inheritdoc
+     *
+     *  NOTE: calling complete on this method will not complete the underlying Scala future
+     */
+    override def toCompletableFuture(): CompletableFuture[T] = this
+
+    override def obtrudeValue(x: T): Unit =
+      throw new UnsupportedOperationException("obtruding a value is not supported for a Scala-originating future")
+
+    override def obtrudeException(t: Throwable): Unit =
+      throw new UnsupportedOperationException("obtruding an exception is not supported for a Scala-originating future")
+
+    override def get(): T = blocking { super.get() }
+
+    override def get(timeout: Long, unit: TimeUnit): T = blocking { super.get(timeout, unit) }
+
+    override def toString(): String = super[CompletableFuture].toString
+  }
+}

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.annotation.nowarn
 import scala.jdk.DurationConverters._
-import scala.jdk.FutureConverters._
+//import scala.jdk.FutureConverters._
 import scala.concurrent.Future
 
 import akka.actor.ActorRefProvider
@@ -43,7 +43,9 @@ import akka.japi.function.{ Function => JFunction }
 import akka.pattern.AskTimeoutException
 import akka.pattern.PromiseActorRef
 import akka.pattern.StatusReply
-import akka.util.{ ByteString, Timeout }
+import akka.util.ByteString
+import akka.util.DispatcherFutureConverters.ScalaFutureOpsWithShiftTo
+import akka.util.Timeout
 
 /**
  * INTERNAL API
@@ -259,7 +261,8 @@ import akka.util.{ ByteString, Timeout }
     new EntityRefImpl[M](
       classicSharding.shardRegion(typeKey.name),
       entityId,
-      typeKey.asInstanceOf[EntityTypeKeyImpl[M]])
+      typeKey.asInstanceOf[EntityTypeKeyImpl[M]],
+      system)
   }
 
   @deprecated("Use Akka Distributed Cluster instead", "2.10.0")
@@ -274,6 +277,7 @@ import akka.util.{ ByteString, Timeout }
         classicSharding.shardRegionProxy(typeKey.name, dataCenter),
         entityId,
         typeKey.asInstanceOf[EntityTypeKeyImpl[M]],
+        system,
         Some(dataCenter))
   }
 
@@ -281,7 +285,8 @@ import akka.util.{ ByteString, Timeout }
     new EntityRefImpl[M](
       classicSharding.shardRegion(typeKey.name),
       entityId,
-      typeKey.asInstanceOf[EntityTypeKeyImpl[M]])
+      typeKey.asInstanceOf[EntityTypeKeyImpl[M]],
+      system)
   }
 
   @deprecated("Use Akka Distributed Cluster instead", "2.10.0")
@@ -296,6 +301,7 @@ import akka.util.{ ByteString, Timeout }
         classicSharding.shardRegionProxy(typeKey.name, dataCenter),
         entityId,
         typeKey.asInstanceOf[EntityTypeKeyImpl[M]],
+        system,
         Some(dataCenter))
   }
 
@@ -328,6 +334,7 @@ import akka.util.{ ByteString, Timeout }
     shardRegion: akka.actor.ActorRef,
     override val entityId: String,
     override val typeKey: EntityTypeKeyImpl[M],
+    system: ActorSystem[_],
     override val dataCenter: Option[String] = None)
     extends javadsl.EntityRef[M]
     with scaladsl.EntityRef[M]
@@ -359,13 +366,13 @@ import akka.util.{ ByteString, Timeout }
   }
 
   override def ask[U](message: JFunction[ActorRef[U], M], timeout: Duration): CompletionStage[U] =
-    ask[U](replyTo => message.apply(replyTo))(timeout.toScala).asJava
+    ask[U](replyTo => message.apply(replyTo))(timeout.toScala).asJava(system.executionContext)
 
   override def askWithStatus[Res](f: ActorRef[StatusReply[Res]] => M)(implicit timeout: Timeout): Future[Res] =
     StatusReply.flattenStatusFuture(ask[StatusReply[Res]](f))
 
   override def askWithStatus[Res](f: ActorRef[StatusReply[Res]] => M, timeout: Duration): CompletionStage[Res] =
-    askWithStatus(f.apply)(timeout.toScala).asJava
+    askWithStatus(f.apply)(timeout.toScala).asJava(system.executionContext)
 
   /** Similar to [[akka.actor.typed.scaladsl.AskPattern.PromiseRef]] but for an `EntityRef` target. */
   @InternalApi
@@ -435,7 +442,7 @@ import akka.util.{ ByteString, Timeout }
   override private[akka] def asJava: javadsl.EntityRef[M] = this
 
   private[internal] def withDataCenter(dataCenter: Option[String]): EntityRefImpl[M] =
-    new EntityRefImpl[M](shardRegion, entityId, typeKey, dataCenter)
+    new EntityRefImpl[M](shardRegion, entityId, typeKey, system, dataCenter)
 }
 
 /**

--- a/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
+++ b/akka-cluster-sharding-typed/src/main/scala/akka/cluster/sharding/typed/internal/ClusterShardingImpl.scala
@@ -12,7 +12,6 @@ import java.util.concurrent.ConcurrentHashMap
 
 import scala.annotation.nowarn
 import scala.jdk.DurationConverters._
-//import scala.jdk.FutureConverters._
 import scala.concurrent.Future
 
 import akka.actor.ActorRefProvider

--- a/akka-coordination/src/main/scala/akka/coordination/lease/internal/LeaseAdapter.scala
+++ b/akka-coordination/src/main/scala/akka/coordination/lease/internal/LeaseAdapter.scala
@@ -8,7 +8,7 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 import java.util.function.Consumer
 
-import scala.jdk.FutureConverters._
+import scala.jdk.FutureConverters.CompletionStageOps
 import scala.jdk.OptionConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -17,6 +17,7 @@ import akka.annotation.InternalApi
 import akka.coordination.lease.LeaseSettings
 import akka.coordination.lease.javadsl.{ Lease => JavaLease }
 import akka.coordination.lease.scaladsl.{ Lease => ScalaLease }
+import akka.util.DispatcherFutureConverters.ScalaFutureOpsWithShiftTo
 
 /**
  * INTERNAL API
@@ -24,13 +25,16 @@ import akka.coordination.lease.scaladsl.{ Lease => ScalaLease }
 @InternalApi
 final private[akka] class LeaseAdapter(delegate: ScalaLease)(implicit val ec: ExecutionContext) extends JavaLease {
 
-  override def acquire(): CompletionStage[java.lang.Boolean] = delegate.acquire().map(Boolean.box).asJava
+  override def acquire(): CompletionStage[java.lang.Boolean] =
+    delegate.acquire().map(Boolean.box)(ExecutionContext.parasitic).asJava(ec)
 
   override def acquire(leaseLostCallback: Consumer[Optional[Throwable]]): CompletionStage[java.lang.Boolean] = {
-    delegate.acquire(o => leaseLostCallback.accept(o.toJava)).map(Boolean.box).asJava
+    delegate.acquire(o => leaseLostCallback.accept(o.toJava)).map(Boolean.box)(ExecutionContext.parasitic).asJava(ec)
   }
 
-  override def release(): CompletionStage[java.lang.Boolean] = delegate.release().map(Boolean.box).asJava
+  override def release(): CompletionStage[java.lang.Boolean] =
+    delegate.release().map(Boolean.box)(ExecutionContext.parasitic).asJava(ec)
+
   override def checkLease(): Boolean = delegate.checkLease()
   override def getSettings(): LeaseSettings = delegate.settings
 }
@@ -43,13 +47,13 @@ final private[akka] class LeaseAdapterToScala(val delegate: JavaLease)(implicit 
     extends ScalaLease(delegate.getSettings()) {
 
   override def acquire(): Future[Boolean] =
-    delegate.acquire().asScala.map(Boolean.unbox)
+    delegate.acquire().asScala.map(Boolean.unbox)(ExecutionContext.parasitic)
 
   override def acquire(leaseLostCallback: Option[Throwable] => Unit): Future[Boolean] =
-    delegate.acquire(o => leaseLostCallback(o.toScala)).asScala.map(Boolean.unbox)
+    delegate.acquire(o => leaseLostCallback(o.toScala)).asScala.map(Boolean.unbox)(ExecutionContext.parasitic)
 
   override def release(): Future[Boolean] =
-    delegate.release().asScala.map(Boolean.unbox)
+    delegate.release().asScala.map(Boolean.unbox)(ExecutionContext.parasitic)
 
   override def checkLease(): Boolean =
     delegate.checkLease()

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/EventsBySliceFirehoseQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/javadsl/EventsBySliceFirehoseQuery.scala
@@ -10,7 +10,6 @@ import java.util.Optional
 import java.util.concurrent.CompletionStage
 
 import scala.concurrent.ExecutionContext
-import scala.jdk.FutureConverters._
 import scala.jdk.OptionConverters._
 
 import akka.NotUsed
@@ -20,6 +19,7 @@ import akka.persistence.query.javadsl.ReadJournal
 import akka.persistence.query.typed.EventEnvelope
 import akka.persistence.query.typed.scaladsl
 import akka.stream.javadsl.Source
+import akka.util.DispatcherFutureConverters.ScalaFutureOpsWithShiftTo
 
 object EventsBySliceFirehoseQuery {
   val Identifier: String = scaladsl.EventsBySliceFirehoseQuery.Identifier
@@ -78,15 +78,20 @@ final class EventsBySliceFirehoseQuery(delegate: scaladsl.EventsBySliceFirehoseQ
   }
 
   override def timestampOf(persistenceId: String, sequenceNr: Long): CompletionStage[Optional[Instant]] =
-    delegate.timestampOf(persistenceId, sequenceNr).map(_.toJava)(ExecutionContext.parasitic).asJava
+    delegate
+      .timestampOf(persistenceId, sequenceNr)
+      .map(_.toJava)(ExecutionContext.parasitic)
+      .asJava(delegate.system.dispatcher)
 
   override def loadEnvelope[Event](persistenceId: String, sequenceNr: Long): CompletionStage[EventEnvelope[Event]] =
-    delegate.loadEnvelope[Event](persistenceId, sequenceNr).asJava
+    delegate.loadEnvelope[Event](persistenceId, sequenceNr).asJava(delegate.system.dispatcher)
 
   override def latestEventTimestamp(
       entityType: String,
       minSlice: Int,
       maxSlice: Int): CompletionStage[Optional[Instant]] =
-    delegate.latestEventTimestamp(entityType, minSlice, maxSlice).map(_.toJava)(ExecutionContext.parasitic).asJava
-
+    delegate
+      .latestEventTimestamp(entityType, minSlice, maxSlice)
+      .map(_.toJava)(ExecutionContext.parasitic)
+      .asJava(delegate.system.dispatcher)
 }

--- a/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/EventsBySliceFirehoseQuery.scala
+++ b/akka-persistence-query/src/main/scala/akka/persistence/query/typed/scaladsl/EventsBySliceFirehoseQuery.scala
@@ -14,6 +14,7 @@ import com.typesafe.config.Config
 
 import akka.NotUsed
 import akka.actor.ExtendedActorSystem
+import akka.annotation.InternalApi
 import akka.persistence.Persistence
 import akka.persistence.query.Offset
 import akka.persistence.query.PersistenceQuery
@@ -45,7 +46,10 @@ object EventsBySliceFirehoseQuery {
  * for the default [[EventsBySliceFirehoseQuery#Identifier]]. See `reference.conf`.
  */
 @nowarn("msg=never used")
-final class EventsBySliceFirehoseQuery(system: ExtendedActorSystem, config: Config, cfgPath: String)
+final class EventsBySliceFirehoseQuery(
+    @InternalApi /** Internal API */ private[akka] val system: ExtendedActorSystem,
+    config: Config,
+    cfgPath: String)
     extends ReadJournal
     with EventsBySliceQuery
     with EventsBySliceStartingFromSnapshotsQuery


### PR DESCRIPTION
The Scala standard library's conversion from Scala future to Java CompletionStage defines the "non-`Async`" versions to effectively call the `Async` version with the Java common `ForkJoinPool` specified.  This subtly conflicts with the common understanding of the difference between the non-`Async` version, and the `Async`version, as evidenced by various AI answers:

Copilot

> *thenCompose*: Uses the thread of the previous stage; no new thread pool unless explicitly provided.
> *thenComposeAsync*: If you don’t pass an Executor, it uses the ForkJoinPool.commonPool().  If you do pass an Executor, it uses that.

Gemini

> *thenCompose* (without "Async") aims to run the dependent task on the same thread that completed the previous CompletableFuture.
> *thenComposeAsync* guarantees that the dependent task will run on a different thread (either the default ForkJoinPool.commonPool() Executor or a specific Executor you provide).

The parasitic behavior of the non-`Async` version is not desirable for the futures returned by Akka (consider that the future returned from asking a remote actor would be completed on the remoting dispatcher!), but there's not a great reason to use the common FJP in an Akka application: the default dispatcher provides an FJP which is well-suited to short CPU-bound tasks (including with better observability).

This adapts the Scala standard library's conversion to one where the executor to prefer is specified at the time of conversion.  CompletionStage-returning calls where it's practical to shift onto the default dispatcher are then adapted to use this:

* asks of `EntityRef`s in typed cluster sharding
* coordination lease operations
* events-by-slice firehose methods which return completion stages